### PR TITLE
[UPGRADE] Golden Path -> 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.2-rc2",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8177,9 +8177,9 @@
       }
     },
     "golden-path": {
-      "version": "1.1.4-rc2",
-      "resolved": "https://registry.npmjs.org/golden-path/-/golden-path-1.1.4-rc2.tgz",
-      "integrity": "sha512-WDdOQ8/5XfOFaxlUMQqYi8B/zJwCn3PSWodws0cbyk0tNiDaDxAhhkVME3s7WYXHkP0KuTm3PMnivSEOWSrVEA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/golden-path/-/golden-path-1.1.4.tgz",
+      "integrity": "sha512-2Fk5lGpPzIH1sboah3bN+j1tLsTjiMewnHGEvMwgOdc03n+yqjxvkgbBLSRq2XELzWFv1iqjXTNmjEQF4Z7/yg=="
     },
     "good-listener": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.2-rc1",
+  "version": "5.0.2-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8177,9 +8177,9 @@
       }
     },
     "golden-path": {
-      "version": "1.1.4-rc",
-      "resolved": "https://registry.npmjs.org/golden-path/-/golden-path-1.1.4-rc.tgz",
-      "integrity": "sha512-Nd1IqmQoHDt2YE+kQaLb4Zo/3iXUzE5pADxxgnCOTHQPiWLEi0z+up7sH3Zl9piG4B62eMUtPILjTGZhzawIqQ=="
+      "version": "1.1.4-rc2",
+      "resolved": "https://registry.npmjs.org/golden-path/-/golden-path-1.1.4-rc2.tgz",
+      "integrity": "sha512-WDdOQ8/5XfOFaxlUMQqYi8B/zJwCn3PSWodws0cbyk0tNiDaDxAhhkVME3s7WYXHkP0KuTm3PMnivSEOWSrVEA=="
     },
     "good-listener": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.2-rc",
+  "version": "5.0.2-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.1",
+  "version": "5.0.2-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8177,9 +8177,9 @@
       }
     },
     "golden-path": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/golden-path/-/golden-path-1.1.3.tgz",
-      "integrity": "sha512-A9jtdGeQET2PTrQZL7d0BRsAelHO1cmjPCQXdJaDSS5gxiknia2X1veEMWEt+opjYJbbG0SI94mKYJAdbJbygA=="
+      "version": "1.1.4-rc",
+      "resolved": "https://registry.npmjs.org/golden-path/-/golden-path-1.1.4-rc.tgz",
+      "integrity": "sha512-Nd1IqmQoHDt2YE+kQaLb4Zo/3iXUzE5pADxxgnCOTHQPiWLEi0z+up7sH3Zl9piG4B62eMUtPILjTGZhzawIqQ=="
     },
     "good-listener": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.2-rc",
+  "version": "5.0.2-rc1",
   "description": "React Functional Context",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.1",
+  "version": "5.0.2-rc",
   "description": "React Functional Context",
   "keywords": [
     "react",
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "typings": "index.d.ts",
   "dependencies": {
-    "golden-path": "^1.1.3"
+    "golden-path": "1.1.4-rc"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.2-rc1",
+  "version": "5.0.2-rc2",
   "description": "React Functional Context",
   "keywords": [
     "react",
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "typings": "index.d.ts",
   "dependencies": {
-    "golden-path": "1.1.4-rc"
+    "golden-path": "1.1.4-rc2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wisteria",
-  "version": "5.0.2-rc2",
+  "version": "5.0.2",
   "description": "React Functional Context",
   "keywords": [
     "react",
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "typings": "index.d.ts",
   "dependencies": {
-    "golden-path": "1.1.4-rc2"
+    "golden-path": "^1.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/useStateManagement/index.js
+++ b/src/useStateManagement/index.js
@@ -15,6 +15,14 @@ const useStateManagement = (initialState, derivedStateSyncers, name) => {
     const [state, setState] = React.useState(initialState);
     const [initState, setInitState] = React.useState(true);
 
+    if (typeof window !== 'undefined') {
+        if (!window.wisteriaRenderCount) {
+            window.wisteriaRenderCount = 0;
+        }
+
+        window.wisteriaRenderCount++;
+    }
+
     const setContext = React.useCallback((path, value) => {
         if (isInDebugMode()) {
             traceUpdates({ name, path, value });

--- a/src/useStateManagement/index.js
+++ b/src/useStateManagement/index.js
@@ -15,14 +15,6 @@ const useStateManagement = (initialState, derivedStateSyncers, name) => {
     const [state, setState] = React.useState(initialState);
     const [initState, setInitState] = React.useState(true);
 
-    if (typeof window !== 'undefined') {
-        if (!window.wisteriaRenderCount) {
-            window.wisteriaRenderCount = 0;
-        }
-
-        window.wisteriaRenderCount++;
-    }
-
     const setContext = React.useCallback((path, value) => {
         if (isInDebugMode()) {
             traceUpdates({ name, path, value });


### PR DESCRIPTION
Ref -> https://github.com/Attrash-Islam/golden-path/pull/9 🎉 

This fix has been done in order to improve `react-wisteria` performance.
This change will not perform the functional update if the leaf has the same value and will return same reference.
**(See added spec - Was failing before this change)**

When we update the Wisteria state we call the updater from `golden-path` which was breaking the path reference in order to update values with their same current values which cause state reference to get changed for react state which forced a re-render.. With this change, the `golden-path` will ignore the update and return same reference which gives React an indication not to re-render!

### React Wisteria updates

![image](https://user-images.githubusercontent.com/7091543/123417269-3edc6380-d5c0-11eb-8246-3140f20b1d70.png)

If the `updater` didn't changed the state and returned it as is then React will ignore the need for re-rendering.

On some of Fiverr's pages that improved JavaScript execution about **~36%**!! 🎉 

## Before

![image](https://user-images.githubusercontent.com/7091543/123418597-e6a66100-d5c1-11eb-9db1-22911471a9f2.png)

## After

![image](https://user-images.githubusercontent.com/7091543/123418554-d8f0db80-d5c1-11eb-92ad-d717967ec994.png)